### PR TITLE
Default, Step3

### DIFF
--- a/src/main/java/io/hhplus/hh_cleanarchitecture/application/controller/LectureReservationController.java
+++ b/src/main/java/io/hhplus/hh_cleanarchitecture/application/controller/LectureReservationController.java
@@ -1,0 +1,58 @@
+package io.hhplus.hh_cleanarchitecture.application.controller;
+
+
+import io.hhplus.hh_cleanarchitecture.application.facade.LectureManagementFacade;
+import io.hhplus.hh_cleanarchitecture.application.request.ReservationRequest;
+import io.hhplus.hh_cleanarchitecture.application.response.ReservationResponse;
+import io.hhplus.hh_cleanarchitecture.domain.dto.ReservationDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController("/lecture")
+@RequiredArgsConstructor
+public class LectureReservationController {
+
+    private final LectureManagementFacade lectureManagementFacade;
+
+
+    /**
+     *  특강 신청 API
+     */
+    @PostMapping("/reservations")
+    public ResponseEntity<ReservationDto> registerLecture(@RequestBody ReservationRequest reservation) {
+        return ResponseEntity.ok(lectureManagementFacade.registerLecture(reservation));
+    }
+
+
+    /**
+     * 특강 신청 여부 조회 API
+     */
+    @GetMapping("/reservation/{userId}")
+    public ResponseEntity<Boolean> lectureReservedByUser(@PathVariable long userId) {
+        return ResponseEntity.ok(lectureManagementFacade.lectureReservedByUser(userId));
+    }
+
+
+    /**
+     * 날짜별로 현재 신청 가능한 특강 조회하는 API
+     */
+    @GetMapping("/reservation/date")
+    public ResponseEntity<List<ReservationResponse>> lectureGroupedByDate(){
+        return ResponseEntity.ok(lectureManagementFacade.lectureGroupedByDate());
+    }
+
+
+    /**
+     * userId로 특강 신청완료된 목록 조회 API
+     */
+    @GetMapping("/reservation/{userId}/reserved")
+    public ResponseEntity<List<ReservationDto>> getUserReservations(@PathVariable long userId) {
+        return ResponseEntity.ok(lectureManagementFacade.getUserReservations(userId));
+    }
+
+
+
+}

--- a/src/main/java/io/hhplus/hh_cleanarchitecture/application/facade/LectureManagementFacade.java
+++ b/src/main/java/io/hhplus/hh_cleanarchitecture/application/facade/LectureManagementFacade.java
@@ -1,0 +1,90 @@
+package io.hhplus.hh_cleanarchitecture.application.facade;
+
+
+import io.hhplus.hh_cleanarchitecture.application.request.ReservationRequest;
+import io.hhplus.hh_cleanarchitecture.application.response.ReservationResponse;
+import io.hhplus.hh_cleanarchitecture.domain.dto.LectureDto;
+import io.hhplus.hh_cleanarchitecture.domain.dto.ReservationDto;
+import io.hhplus.hh_cleanarchitecture.domain.service.InstructorService;
+import io.hhplus.hh_cleanarchitecture.domain.service.LectureService;
+import io.hhplus.hh_cleanarchitecture.domain.service.ReservationService;
+import io.hhplus.hh_cleanarchitecture.infrastructure.entity.Instructor;
+import io.hhplus.hh_cleanarchitecture.infrastructure.entity.Lecture;
+import io.hhplus.hh_cleanarchitecture.infrastructure.entity.Reservation;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class LectureManagementFacade {
+
+    private final LectureService lectureService;
+    private final ReservationService reservationService;
+    private final InstructorService instructorService;
+
+    // 날짜별 강의 조회
+    public List<ReservationResponse> lectureGroupedByDate(){
+        List<Lecture> lectures = lectureService.lectureList();
+
+        return lectures.stream().map(lecture ->{
+            Instructor instructor = instructorService.findById(lecture.getInstructor().getInstructorId());
+
+            return LectureDto.builder()
+                    .lectureId(lecture.getLectureId())
+                    .lectureName(lecture.getLectureName())
+                    .lectureDate(lecture.getLectureDate())
+                    .instructorName(instructor.getInstructorName())
+                    .capacity(lecture.getCapacity())
+                    .build();
+        }).collect(Collectors.groupingBy(LectureDto::getLectureDate))
+                .entrySet()
+                .stream()
+                .map(entry -> new ReservationResponse(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList());
+    }
+
+    // 강의 신청
+    @Transactional
+    public ReservationDto registerLecture(ReservationRequest request) {
+
+        // 해당 강의에 대한 신청이 존재하는지 확인
+        reservationService.isUserReservedLecture(request.getUserId(), request.getLectureId());
+
+        // 해당 강의 조회
+        Lecture lecture = lectureService.findById(request.getLectureId());
+
+        // 저장
+        Reservation reservation = reservationService.registerLecture(lecture, request.getUserId());
+
+        lectureService.updateCapacity(lecture);
+
+        return ReservationDto.builder().reservationId(reservation.getReservationId())
+                .lectureName(reservation.getLecture().getLectureName())
+                .lectureDate(reservation.getLecture().getLectureDate())
+                .build();
+    }
+
+    // 특강 신청 여부
+    public Boolean lectureReservedByUser(long userId) {
+        return reservationService.lectureReservedByUser(userId);
+    }
+
+    // 특강 신청 목록 조회
+    public List<ReservationDto> getUserReservations(long userId) {
+        List<Reservation> reservations = reservationService.getUserReservations(userId);
+
+        return  reservations.stream().map(reservation ->{
+            return ReservationDto.builder()
+                    .reservationId(reservation.getReservationId())
+                    .instructorName(reservation.getLecture().getInstructor().getInstructorName())
+                    .lectureName(reservation.getLecture().getLectureName())
+                    .lectureDate(reservation.getLecture().getLectureDate())
+                    .userId(reservation.getUserId())
+                    .build();
+        }).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/io/hhplus/hh_cleanarchitecture/application/request/ReservationRequest.java
+++ b/src/main/java/io/hhplus/hh_cleanarchitecture/application/request/ReservationRequest.java
@@ -1,0 +1,12 @@
+package io.hhplus.hh_cleanarchitecture.application.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+@AllArgsConstructor
+public class ReservationRequest {
+    private long userId;
+    private long lectureId;
+}

--- a/src/main/java/io/hhplus/hh_cleanarchitecture/application/response/ReservationResponse.java
+++ b/src/main/java/io/hhplus/hh_cleanarchitecture/application/response/ReservationResponse.java
@@ -1,0 +1,16 @@
+package io.hhplus.hh_cleanarchitecture.application.response;
+
+
+import io.hhplus.hh_cleanarchitecture.domain.dto.LectureDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter @Setter @AllArgsConstructor
+public class ReservationResponse {
+    private LocalDate date;
+    private List<LectureDto> lectures;
+}

--- a/src/main/java/io/hhplus/hh_cleanarchitecture/common/ApiControllerAdvice.java
+++ b/src/main/java/io/hhplus/hh_cleanarchitecture/common/ApiControllerAdvice.java
@@ -1,0 +1,27 @@
+package io.hhplus.hh_cleanarchitecture.common;
+
+
+import io.hhplus.hh_cleanarchitecture.common.exception.InstructorNotFoundException;
+import io.hhplus.hh_cleanarchitecture.common.exception.LectureException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+class ApiControllerAdvice extends ResponseEntityExceptionHandler {
+    @ExceptionHandler(value = Exception.class)
+    public ResponseEntity<ErrorMessage> handleException(Exception e) {
+        return ResponseEntity.status(500).body(new ErrorMessage("500", "에러가 발생했습니다."));
+    }
+
+    @ExceptionHandler(value = LectureException.class)
+    public ResponseEntity<ErrorMessage> handleLectureException(LectureException e) {
+        return ResponseEntity.status(e.getCode()).body(new ErrorMessage(String.valueOf(e.getCode()), e.getMessage()));
+    }
+
+    @ExceptionHandler(value = InstructorNotFoundException.class)
+    public ResponseEntity<ErrorMessage> handleInstructorNotFoundException(InstructorNotFoundException e) {
+        return ResponseEntity.status(404).body(new ErrorMessage("404", e.getMessage()));
+    }
+}

--- a/src/main/java/io/hhplus/hh_cleanarchitecture/common/ErrorMessage.java
+++ b/src/main/java/io/hhplus/hh_cleanarchitecture/common/ErrorMessage.java
@@ -1,0 +1,8 @@
+package io.hhplus.hh_cleanarchitecture.common;
+
+public record ErrorMessage(
+        String code,
+        String message
+) {
+}
+

--- a/src/main/java/io/hhplus/hh_cleanarchitecture/common/exception/InstructorNotFoundException.java
+++ b/src/main/java/io/hhplus/hh_cleanarchitecture/common/exception/InstructorNotFoundException.java
@@ -1,0 +1,7 @@
+package io.hhplus.hh_cleanarchitecture.common.exception;
+
+public class InstructorNotFoundException extends RuntimeException {
+    public InstructorNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/io/hhplus/hh_cleanarchitecture/common/exception/LectureException.java
+++ b/src/main/java/io/hhplus/hh_cleanarchitecture/common/exception/LectureException.java
@@ -1,0 +1,14 @@
+package io.hhplus.hh_cleanarchitecture.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class LectureException extends RuntimeException {
+    private final int code;
+
+    public LectureException(int code, String message) {
+        super(message);
+        this.code = code;
+    }
+
+}

--- a/src/main/java/io/hhplus/hh_cleanarchitecture/domain/dto/InstructorDto.java
+++ b/src/main/java/io/hhplus/hh_cleanarchitecture/domain/dto/InstructorDto.java
@@ -1,0 +1,16 @@
+package io.hhplus.hh_cleanarchitecture.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+@AllArgsConstructor
+@Builder
+public class InstructorDto {
+
+    private long instructorId;
+    private String instructorName;
+
+}

--- a/src/main/java/io/hhplus/hh_cleanarchitecture/domain/dto/LectureDto.java
+++ b/src/main/java/io/hhplus/hh_cleanarchitecture/domain/dto/LectureDto.java
@@ -1,0 +1,23 @@
+package io.hhplus.hh_cleanarchitecture.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter @Setter
+@AllArgsConstructor
+@Builder
+public class LectureDto {
+
+        private long lectureId;
+        private String lectureName;
+        private long instructorId;
+        private String instructorName;
+        private LocalDate lectureDate;
+        private int capacity;
+
+
+}

--- a/src/main/java/io/hhplus/hh_cleanarchitecture/domain/dto/ReservationDto.java
+++ b/src/main/java/io/hhplus/hh_cleanarchitecture/domain/dto/ReservationDto.java
@@ -1,0 +1,20 @@
+package io.hhplus.hh_cleanarchitecture.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter @Setter
+@AllArgsConstructor
+@Builder
+public class ReservationDto {
+
+    private long reservationId;
+    private long userId;
+    private String lectureName;
+    private String instructorName;
+    private LocalDate lectureDate;
+}

--- a/src/main/java/io/hhplus/hh_cleanarchitecture/domain/service/InstructorService.java
+++ b/src/main/java/io/hhplus/hh_cleanarchitecture/domain/service/InstructorService.java
@@ -1,0 +1,20 @@
+package io.hhplus.hh_cleanarchitecture.domain.service;
+
+
+import io.hhplus.hh_cleanarchitecture.common.exception.InstructorNotFoundException;
+import io.hhplus.hh_cleanarchitecture.infrastructure.entity.Instructor;
+import io.hhplus.hh_cleanarchitecture.infrastructure.repository.InstructorJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class InstructorService {
+
+    private final InstructorJpaRepository instructorJpaRepository;
+
+    // 인스트럭터 조회
+    public Instructor findById(long instructorId) {
+        return instructorJpaRepository.findById(instructorId).orElseThrow(() -> new InstructorNotFoundException("강사가 존재하지 않습니다."));
+    }
+}

--- a/src/main/java/io/hhplus/hh_cleanarchitecture/domain/service/LectureService.java
+++ b/src/main/java/io/hhplus/hh_cleanarchitecture/domain/service/LectureService.java
@@ -1,0 +1,44 @@
+package io.hhplus.hh_cleanarchitecture.domain.service;
+
+import io.hhplus.hh_cleanarchitecture.common.exception.LectureException;
+import io.hhplus.hh_cleanarchitecture.infrastructure.entity.Lecture;
+import io.hhplus.hh_cleanarchitecture.infrastructure.repository.LectureJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LectureService {
+
+    private final LectureJpaRepository lectureJpaRepository;
+
+    // lecture List 조회
+    public List<Lecture> lectureList(){
+        LocalDate currentDate = LocalDate.now();
+        List<Lecture> lectures = lectureJpaRepository.findByLectureDateGreaterThanEqualAndCapacityLessThan(currentDate, 30);
+        if(lectures.isEmpty()){
+            throw new LectureException(404, "조회결과가 없습니다.");
+        }
+        return lectures;
+    }
+
+    // Lecture 조회
+    @Transactional
+    public Lecture findById(long lectureId){
+        return lectureJpaRepository.findByLectureIdAndCapacityLessThan(lectureId, 30)
+                .orElseThrow(() -> new LectureException(404, "마감된 특강입니다."));
+    }
+
+    // 신청수 증가
+    public void updateCapacity(Lecture lecture) {
+        if (lecture.getCapacity() > 30) {
+            throw new LectureException(409, "강의 정원이 초과되었습니다.");
+        }
+        lecture.setCapacity(lecture.getCapacity() + 1);
+    }
+
+}

--- a/src/main/java/io/hhplus/hh_cleanarchitecture/domain/service/ReservationService.java
+++ b/src/main/java/io/hhplus/hh_cleanarchitecture/domain/service/ReservationService.java
@@ -1,0 +1,54 @@
+package io.hhplus.hh_cleanarchitecture.domain.service;
+
+
+import io.hhplus.hh_cleanarchitecture.common.exception.LectureException;
+import io.hhplus.hh_cleanarchitecture.infrastructure.entity.Lecture;
+import io.hhplus.hh_cleanarchitecture.infrastructure.entity.Reservation;
+import io.hhplus.hh_cleanarchitecture.infrastructure.repository.ReservationJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationService {
+
+    private final ReservationJpaRepository reservationJpaRepository;
+
+    // 특강 신청
+    @Transactional
+    public Reservation registerLecture(Lecture lecture, long userId) {
+
+        if(lecture == null) throw new LectureException(404, "현재 특강을 신청할 수 없습니다.");
+
+        Reservation reservation = new Reservation();
+        reservation.setLecture(lecture);
+        reservation.setUserId(userId);
+
+        return reservationJpaRepository.save(reservation);
+    }
+
+    // 해당 강의에 대한 신청이 존재하는지 확인
+    public void isUserReservedLecture(long userId, long lectureId) {
+        if(reservationJpaRepository.existsByUserIdAndLecture_LectureId(userId, lectureId)){
+            throw new LectureException(409, "해당 강의에 대한 신청이 존재합니다.");
+        }
+    }
+
+    // 해당 유저에 대한 특강 신청 여부
+    public boolean lectureReservedByUser(long userId) {
+       return reservationJpaRepository.existsByUserIdAndLectureLectureDateGreaterThanEqual(userId, LocalDate.now());
+    }
+
+    // 특강 신청 목록 조회
+    public List<Reservation> getUserReservations(long userId){
+        List<Reservation> list = reservationJpaRepository.findByUserId(userId);
+        if(list.isEmpty()){
+            throw new LectureException(404, "신청완료된 특강이 없습니다.");
+        }
+        return list;
+    }
+}

--- a/src/main/java/io/hhplus/hh_cleanarchitecture/infrastructure/entity/Instructor.java
+++ b/src/main/java/io/hhplus/hh_cleanarchitecture/infrastructure/entity/Instructor.java
@@ -1,0 +1,26 @@
+package io.hhplus.hh_cleanarchitecture.infrastructure.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@Table(name= "INSTRUCTOR")
+public class Instructor {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="INSTRUCTOR_ID")
+    private long instructorId;
+
+    @Column(name="INSTRUCTOR_NAME")
+    private String instructorName;
+
+    @OneToMany(mappedBy = "instructor", fetch = FetchType.LAZY)
+    private List<Lecture> lectures;
+
+}

--- a/src/main/java/io/hhplus/hh_cleanarchitecture/infrastructure/entity/Lecture.java
+++ b/src/main/java/io/hhplus/hh_cleanarchitecture/infrastructure/entity/Lecture.java
@@ -1,0 +1,33 @@
+package io.hhplus.hh_cleanarchitecture.infrastructure.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Entity @Getter @Setter
+@Table(name = "LECTURE")
+public class Lecture {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "LECTURE_ID")
+    private long lectureId;
+
+    @Column(name = "LECTURE_NAME", nullable = false)
+    private String lectureName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="INSTRUCTOR_ID")
+    private Instructor instructor;
+
+
+    @Column(name = "LECTURE_DATE", nullable = false)
+    private LocalDate lectureDate;
+
+    @Column(name="CAPACITY", nullable = false)
+    private int capacity;
+
+
+}

--- a/src/main/java/io/hhplus/hh_cleanarchitecture/infrastructure/entity/Reservation.java
+++ b/src/main/java/io/hhplus/hh_cleanarchitecture/infrastructure/entity/Reservation.java
@@ -1,0 +1,23 @@
+package io.hhplus.hh_cleanarchitecture.infrastructure.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity @Getter @Setter
+@Table(name= "RESERVATION")
+public class Reservation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "RESERVATION_ID")
+    private long reservationId;
+
+    @Column(name = "USER_ID", nullable = false)
+    private long userId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "LECTURE_ID", nullable = false)
+    private Lecture lecture;
+
+}

--- a/src/main/java/io/hhplus/hh_cleanarchitecture/infrastructure/repository/InstructorJpaRepository.java
+++ b/src/main/java/io/hhplus/hh_cleanarchitecture/infrastructure/repository/InstructorJpaRepository.java
@@ -1,0 +1,12 @@
+package io.hhplus.hh_cleanarchitecture.infrastructure.repository;
+
+import io.hhplus.hh_cleanarchitecture.infrastructure.entity.Instructor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+;
+
+@Repository
+public interface InstructorJpaRepository extends JpaRepository<Instructor, Long> {
+
+}

--- a/src/main/java/io/hhplus/hh_cleanarchitecture/infrastructure/repository/LectureJpaRepository.java
+++ b/src/main/java/io/hhplus/hh_cleanarchitecture/infrastructure/repository/LectureJpaRepository.java
@@ -1,0 +1,18 @@
+package io.hhplus.hh_cleanarchitecture.infrastructure.repository;
+
+
+import io.hhplus.hh_cleanarchitecture.infrastructure.entity.Lecture;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface LectureJpaRepository extends JpaRepository<Lecture, Long> {
+
+    List<Lecture> findByLectureDateGreaterThanEqualAndCapacityLessThan(LocalDate currentDate, int capacity);
+
+    Optional<Lecture> findByLectureIdAndCapacityLessThan(Long lectureId, int capacity);
+}

--- a/src/main/java/io/hhplus/hh_cleanarchitecture/infrastructure/repository/ReservationJpaRepository.java
+++ b/src/main/java/io/hhplus/hh_cleanarchitecture/infrastructure/repository/ReservationJpaRepository.java
@@ -1,0 +1,19 @@
+package io.hhplus.hh_cleanarchitecture.infrastructure.repository;
+
+
+import io.hhplus.hh_cleanarchitecture.infrastructure.entity.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+public interface ReservationJpaRepository extends JpaRepository<Reservation, Long> {
+
+    boolean existsByUserIdAndLectureLectureDateGreaterThanEqual(Long userId, LocalDate now);
+
+    boolean existsByUserIdAndLecture_LectureId(long userId, long lectureId);
+
+    List<Reservation> findByUserId(long userId);
+}

--- a/src/test/java/io/hhplus/hh_cleanarchitecture/application/facade/LectureManagementFacadeTest.java
+++ b/src/test/java/io/hhplus/hh_cleanarchitecture/application/facade/LectureManagementFacadeTest.java
@@ -1,0 +1,200 @@
+package io.hhplus.hh_cleanarchitecture.application.facade;
+
+
+import io.hhplus.hh_cleanarchitecture.application.request.ReservationRequest;
+import io.hhplus.hh_cleanarchitecture.application.response.ReservationResponse;
+import io.hhplus.hh_cleanarchitecture.domain.dto.ReservationDto;
+import io.hhplus.hh_cleanarchitecture.domain.service.InstructorService;
+import io.hhplus.hh_cleanarchitecture.domain.service.LectureService;
+import io.hhplus.hh_cleanarchitecture.domain.service.ReservationService;
+import io.hhplus.hh_cleanarchitecture.infrastructure.entity.Instructor;
+import io.hhplus.hh_cleanarchitecture.infrastructure.entity.Lecture;
+import io.hhplus.hh_cleanarchitecture.infrastructure.entity.Reservation;
+import io.hhplus.hh_cleanarchitecture.infrastructure.repository.InstructorJpaRepository;
+import io.hhplus.hh_cleanarchitecture.infrastructure.repository.LectureJpaRepository;
+import io.hhplus.hh_cleanarchitecture.infrastructure.repository.ReservationJpaRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Transactional
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class LectureManagementFacadeTest {
+    private static final Logger log = LoggerFactory.getLogger(LectureManagementFacadeTest.class);
+    @Autowired
+    private LectureManagementFacade lectureManagementFacade;
+
+    @Autowired
+    private LectureService lectureService;
+
+    @Autowired
+    private ReservationService reservationService;
+
+    @Autowired
+    private InstructorService instructorService;
+
+    @Autowired
+    private LectureJpaRepository lectureJpaRepository;
+
+    @Autowired
+    private InstructorJpaRepository instructorJpaRepository;
+    @Autowired
+    private ReservationJpaRepository reservationJpaRepository;
+
+    @DisplayName("날짜별로 묶어서 조회가 되는지 확인하는 테스트")
+    @Test
+    void lectureGroupedByDateTest(){
+
+        // Given: 테스트 데이터 준비
+        Instructor instructor = new Instructor();
+        instructor.setInstructorName("강사 1");
+        instructor = instructorJpaRepository.save(instructor);
+
+        Lecture lecture1 = new Lecture();
+        lecture1.setLectureName("강의 1");
+        lecture1.setLectureDate(LocalDate.of(2024, 10, 21));
+        lecture1.setInstructor(instructor);
+        lecture1.setCapacity(0);
+        lectureJpaRepository.save(lecture1);
+
+        Lecture lecture2 = new Lecture();
+        lecture2.setLectureName("강의 2");
+        lecture2.setLectureDate(LocalDate.of(2024, 10, 21));
+        lecture2.setInstructor(instructor);
+        lecture2.setCapacity(0);
+        lectureJpaRepository.save(lecture2);
+
+        Lecture lecture3 = new Lecture();
+        lecture3.setLectureName("강의 3");
+        lecture3.setLectureDate(LocalDate.of(2024, 10, 22));
+        lecture3.setInstructor(instructor);
+        lecture3.setCapacity(0);
+        lectureJpaRepository.save(lecture3);
+
+        // When = 강의 목록 조회
+        List<ReservationResponse> result = lectureManagementFacade.lectureGroupedByDate();
+
+        // THEN
+        // 결과가 null이 아닌지 검증
+        assertNotNull(result);
+        // 결과가 비어있지 않은지 검증
+        assertFalse(result.isEmpty());
+
+        ReservationResponse group1 = result.stream()
+                .filter(group -> group.getDate().equals(LocalDate.of(2024, 10, 21)))
+                .findFirst().orElse(null);
+        assertNotNull(group1); // 해당 날짜에 대한 그룹이 있는지 검증
+        assertEquals(2, group1.getLectures().size()); // 10.21의 강의 개수가 2개인지 검증
+
+        ReservationResponse group2 = result.stream()
+                .filter(group -> group.getDate().equals(LocalDate.of(2024, 10, 22)))
+                .findFirst().orElse(null);
+        assertNotNull(group2); // 해당 날짜에 대한 그룹이 있는지 검증
+        assertEquals(1, group2.getLectures().size()); // 10.22의 강의 개수가 1개인지 검증
+
+    }
+
+    @DisplayName("강의 신청이 등록되는지 테스트")
+    @Test
+    public void registerLectureTest() {
+        // Given: 테스트 데이터 준비
+        Instructor instructor = new Instructor();
+        instructor.setInstructorName("강사 1");
+        instructor = instructorJpaRepository.save(instructor);
+
+        Lecture lecture = new Lecture();
+        lecture.setLectureName("강의 1");
+        lecture.setLectureDate(LocalDate.of(2024, 10, 21));
+        lecture.setInstructor(instructor);
+        lecture.setCapacity(0);
+        lectureJpaRepository.save(lecture);
+
+        ReservationRequest request = new ReservationRequest(1, lecture.getLectureId());
+
+        // When: 강의 신청
+        ReservationDto result = lectureManagementFacade.registerLecture(request);
+
+        // Then: 결과 검증
+        assertNotNull(result);
+        assertEquals("강의 1", result.getLectureName()); // 강의명이 정확한지 검증
+    }
+
+    @DisplayName("특정 사용자가 강의를 신청했는지 여부를 확인하는 테스트")
+    @Test
+    public void lectureReservedByUserTest() {
+        // Given: 테스트 데이터 준비
+        Instructor instructor = new Instructor();
+        instructor.setInstructorName("강사 1");
+        instructor = instructorJpaRepository.save(instructor);
+
+        Lecture lecture = new Lecture();
+        lecture.setLectureName("강의 1");
+        lecture.setLectureDate(LocalDate.of(2024, 10, 21));
+        lecture.setInstructor(instructor);
+        lecture.setCapacity(30);
+        lectureJpaRepository.save(lecture);
+
+        // 강의 신청
+        Reservation reservation = new Reservation();
+        reservation.setLecture(lecture);
+        reservation.setUserId(1L);
+        reservationJpaRepository.save(reservation);
+
+        // When: 특정 사용자가 강의를 신청했는지 확인
+        boolean isReserved = lectureManagementFacade.lectureReservedByUser(1);
+
+        // Then: 결과 검증
+        assertTrue(isReserved); // 강의 신청이 되었는지 확인
+    }
+
+    @DisplayName("특정 사용자의 예약 목록을 조회하는 테스트")
+    @Test
+    public void getUserReservationsTest() {
+        // Given: 테스트 데이터 준비
+        Instructor instructor = new Instructor();
+        instructor.setInstructorName("강사 1");
+        instructor = instructorJpaRepository.save(instructor);
+
+        Lecture lecture1 = new Lecture();
+        lecture1.setLectureName("강의 1");
+        lecture1.setLectureDate(LocalDate.of(2024, 10, 21));
+        lecture1.setInstructor(instructor);
+        lecture1.setCapacity(0);
+        lectureJpaRepository.save(lecture1);
+
+        Lecture lecture2 = new Lecture();
+        lecture2.setLectureName("강의 2");
+        lecture2.setLectureDate(LocalDate.of(2024, 10, 22));
+        lecture2.setInstructor(instructor);
+        lecture2.setCapacity(0);
+        lectureJpaRepository.save(lecture2);
+
+        // 강의 신청
+        Reservation reservation1 = new Reservation();
+        reservation1.setLecture(lecture1);
+        reservation1.setUserId(100);
+        reservationJpaRepository.save(reservation1);
+
+        Reservation reservation2 = new Reservation();
+        reservation2.setLecture(lecture2);
+        reservation2.setUserId(100);
+        reservationJpaRepository.save(reservation2);
+
+        // When: 사용자의 예약 목록 조회
+        List<ReservationDto> result = lectureManagementFacade.getUserReservations(100);
+
+        // Then: 결과 검증
+        assertNotNull(result); // 결과가 null이 아닌지 검증
+        assertEquals(2, result.size()); // 강의 개수가 정확한지 검증
+    }
+
+}

--- a/src/test/java/io/hhplus/hh_cleanarchitecture/domain/service/InstructorServiceTest.java
+++ b/src/test/java/io/hhplus/hh_cleanarchitecture/domain/service/InstructorServiceTest.java
@@ -1,0 +1,54 @@
+package io.hhplus.hh_cleanarchitecture.domain.service;
+
+
+import io.hhplus.hh_cleanarchitecture.common.exception.InstructorNotFoundException;
+import io.hhplus.hh_cleanarchitecture.infrastructure.entity.Instructor;
+import io.hhplus.hh_cleanarchitecture.infrastructure.repository.InstructorJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+
+class InstructorServiceTest {
+
+    InstructorService instructorService;
+
+    @Mock
+    InstructorJpaRepository instructorJpaRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        instructorService = new InstructorService(instructorJpaRepository);
+    }
+
+    @DisplayName("인스트럭터가 조회될경우 테스트")
+    @Test
+    void instructorFound() {
+        long instructorId = 1L;
+        Instructor instructor = new Instructor();
+        instructor.setInstructorId(instructorId);
+        instructor.setInstructorName("test");
+
+        when(instructorJpaRepository.findById(instructorId)).thenReturn(Optional.of(instructor));
+        assert (instructorService.findById(instructorId).equals(instructor));
+    }
+
+
+    @DisplayName("인스트럭터가 조회되지 않을경우 테스트")
+    @Test
+    void instructorNotFound(){
+        long instructorId = 1L;
+
+        when(instructorJpaRepository.findById(instructorId)).thenReturn(Optional.empty());
+        assertThrows(InstructorNotFoundException.class, () -> instructorService.findById(instructorId));
+    }
+
+}

--- a/src/test/java/io/hhplus/hh_cleanarchitecture/domain/service/LectureServiceTest.java
+++ b/src/test/java/io/hhplus/hh_cleanarchitecture/domain/service/LectureServiceTest.java
@@ -1,0 +1,61 @@
+package io.hhplus.hh_cleanarchitecture.domain.service;
+
+
+import io.hhplus.hh_cleanarchitecture.common.exception.LectureException;
+import io.hhplus.hh_cleanarchitecture.infrastructure.entity.Lecture;
+import io.hhplus.hh_cleanarchitecture.infrastructure.repository.LectureJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+class LectureServiceTest {
+
+    LectureService lectureService;
+
+    @Mock
+    LectureJpaRepository lectureJpaRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        lectureService = new LectureService(lectureJpaRepository);
+    }
+
+
+    @DisplayName("조회한 lecture List가 조회되는지 테스트")
+    @Test
+    void lectureListFound(){
+        List<Lecture> lectures = new ArrayList<>();
+
+        Lecture lectureA = new Lecture();
+        lectureA.setLectureId(1);
+        lectureA.setLectureName("test1");
+        Lecture lectureB = new Lecture();
+        lectureB.setLectureId(2);
+        lectureB.setLectureName("test2");
+
+        lectures.add(lectureA);
+        lectures.add(lectureB);
+
+        when(lectureJpaRepository.findByLectureDateGreaterThanEqualAndCapacityLessThan(LocalDate.now(), 30)).thenReturn(lectures);
+
+        assertDoesNotThrow(() ->  assertIterableEquals(lectures, lectureService.lectureList()));
+    }
+
+    @DisplayName("조회된 Lecture가 없을 경우 테스트")
+    @Test
+    void lectureListNotFound(){
+        when(lectureJpaRepository.findByLectureDateGreaterThanEqualAndCapacityLessThan(LocalDate.now(), 30)).thenReturn(List.of());
+        assertThrows(LectureException.class, () -> lectureService.lectureList());
+    }
+
+}

--- a/src/test/java/io/hhplus/hh_cleanarchitecture/domain/service/ReservationServiceTest.java
+++ b/src/test/java/io/hhplus/hh_cleanarchitecture/domain/service/ReservationServiceTest.java
@@ -1,0 +1,93 @@
+package io.hhplus.hh_cleanarchitecture.domain.service;
+
+
+import io.hhplus.hh_cleanarchitecture.common.exception.LectureException;
+import io.hhplus.hh_cleanarchitecture.infrastructure.entity.Lecture;
+import io.hhplus.hh_cleanarchitecture.infrastructure.entity.Reservation;
+import io.hhplus.hh_cleanarchitecture.infrastructure.repository.ReservationJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+class ReservationServiceTest {
+
+    ReservationService reservationService;
+
+    @Mock
+    ReservationJpaRepository reservationJpaRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        reservationService = new ReservationService(reservationJpaRepository);
+    }
+
+    @DisplayName("신청할 특강이 존재하지 않을 경우")
+    @Test
+    void registerLectureTest() {
+        Lecture lecture = null;
+        assertThrows(LectureException.class, () ->
+                reservationService.registerLecture(lecture, 1L));
+
+    }
+
+    @DisplayName("userId로 특강 신청 여부 확인")
+    @Test
+    void lectureReservedByUserTest() {
+        long userId = 1L;
+
+        when(reservationJpaRepository.existsByUserIdAndLectureLectureDateGreaterThanEqual(userId, LocalDate.now())).thenReturn(true);
+        assertTrue(reservationService.lectureReservedByUser(userId));
+    }
+
+    @DisplayName("해당 강의에 대한 신청이 존재할 경우 테스트")
+    @Test
+    void isUserReservedLectureTrueTest() {
+        long userId = 1L;
+        long lectureId = 1L;
+
+        when(reservationJpaRepository.existsByUserIdAndLecture_LectureId(userId, lectureId)).thenReturn(true);
+        assertThrows(LectureException.class, () ->
+                reservationService.isUserReservedLecture(userId, lectureId));
+    }
+
+    @DisplayName("해당 강의에 대한 신청이 존재하지 않을 경우 테스트")
+    @Test
+    void isUserReservedLectureFalseTest() {
+        long userId = 1L;
+        long lectureId = 1L;
+
+        when(reservationJpaRepository.existsByUserIdAndLecture_LectureId(userId, lectureId)).thenReturn(false);
+        assertDoesNotThrow(() -> reservationService.isUserReservedLecture(userId, lectureId));
+    }
+
+    @DisplayName("특강 신청 내역이 없을경우")
+    @Test
+    void reservationNotFound(){
+        long userId = 1L;
+        when(reservationJpaRepository.findByUserId(userId)).thenReturn(List.of());
+        assertThrows(LectureException.class, () -> reservationService.getUserReservations(userId));
+    }
+
+    @DisplayName("특강 신청 내역이 있을 경우")
+    @Test
+    void reservationFound(){
+        long userId = 1L;
+        Reservation reservation = new Reservation();
+        reservation.setUserId(userId);
+        reservation.setReservationId(1);
+
+        when(reservationJpaRepository.findByUserId(userId)).thenReturn(List.of(reservation));
+        assertDoesNotThrow(() -> assertIterableEquals(List.of(reservation), reservationService.getUserReservations(userId)));
+    }
+
+
+}


### PR DESCRIPTION
git 실수로 프로젝트가 한번 날라가서 급하게 PR만드느라 뭉쳐서 커밋 한 점 양해 부탁드립니다...😨
Step3번 밖에 못했고 단위테스트, 통합테스트에 대해서 부족해 보이는 곳이나 틀린 부분 있으면 조언 부탁드립니다!!
어디든 부족한 점이 보인다면 많이 알려주세요..

---
## 2주차 어려웠던 점

이번 주에 **JPA**를 처음 사용하다 보니 여러 부분에서 구현하는 데 어려움이 있었습니다. 
특히 구현 과정에서 관련 내용을 찾아가며 진행해야하는 부분에서 시간소요가 많이 됐습니다.

### 비관적 락(Pessimistic Lock) 적용 시 문제
이번주는 동시성 과제를 통과해보고자 비관적 락을 적용해보려고 시도했지만, **테스트 통과**에 실패했습니다. 문제를 분석한 결과, @GeneratedValue(strategy = GenerationType.IDENTITY)로 ID를 생성할 때, **ID 생성 방식**으로 인해 충돌이 발생하면서 
**락이 제대로 걸리지 않는 문제**가 발생할 수 있다는 것을 알게 되었습니다. 구글링을 통해 알게 됐기 때문에 정확한지 모르겠지만 
이 문제를 해결하기 위해 더 공부해서 다음 동시성 제어 관련 과제를 해결해보고 싶습니다.

---

## 과제 체크리스트
## Default
- [x] 아키텍처 준수를 위한 애플리케이션 패키지 설계
### 패키지 구조 설명
  - 각 계층의 책임을 명확히 분리하고자 설계했습니다.

1. application
사용자 요청을 처리하고 비즈니스 로직을 조정하는 계층입니다. 컨트롤러와 파사드가 포함되어 있어, 클라이언트와 비즈니스 로직 간의 상호작용을 관리합니다.
2. common
애플리케이션 전반에서 공통적으로 사용하는 기능을 제공하거나, 예외 처리를 담당하는 계층입니다. 여러 계층에서 반복적으로 사용되는 코드를 효율적으로 관리합니다.
3. domain
애플리케이션의 핵심 도메인 모델과 관련된 로직을 처리하는 계층입니다. 도메인 객체의 DTO(데이터 전송 객체)와 각 비즈니스 로직을 처리하는 서비스가 포함됩니다.
4. infrastructure
데이터베이스와의 상호작용을 담당하는 계층입니다. 엔티티 클래스와 레포지토리 클래스가 위치하며, 데이터베이스의 CRUD 작업을 처리합니다.

- [x] 특강 도메인 테이블 설계 및 목록/신청 등 기본 기능 구현
- [x] 각 기능에 대한 단위 테스트 작성


## STEP 3
- [x] 설계한 테이블에 대한 ERD 및 이유를 설명하는 README 작성
- [x] 선착순 30명 이후의 신청자의 경우 실패하도록 개선


1. LECTURE와 INSTRUCTOR 간의 일대다 관계:
    - 한 명의 강사가 여러 강의를 개설할 수 있다는 점에서 일대다(Many-to-One) 관계로 설정했습니다.  
      LECTURE 테이블은 INSTRUCTOR 테이블의 외래 키를 가지고 있고, 강의는 항상 특정 강사와 연결됩니다.

2. RESERVATION 테이블을 통해 유저의 신청 관리:

    - RESERVATION 테이블은 유저가 특정 강의를 신청하면 이를 저장하는 중간 테이블로서 기능합니다.  
      유저가 강의를 신청할 때 LECTURE ID와 함께 저장합니다.

3. 연관 관계를 통한 데이터 조회:
    - 강의를 신청한 후에, 예약 목록을 조회할 때 LECTURE 테이블의 ID를 통해 RESERVATION 테이블과 LECTURE 테이블 간의 관계를 이용하여 데이터를 쉽게 조회하고,  
      LECTURE 테이블의 외래 키로 가지고 있는 INSTRUCTOR ID를 활용해 강사의 정보도 조회할 수 있도록 설계했습니다.

<img width="797" alt="ERD" src="https://github.com/user-attachments/assets/4b73b020-1210-4c80-8b4d-ee98c78cceea">

---